### PR TITLE
Update conan dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ pmm(CONAN SETTINGS ${conan_std})
 conan_set_find_paths()
 
 # Find-package the Boost that Conan gave us
-find_package(Boost 1.68.0 REQUIRED)
+find_package(Boost 1.70.0 REQUIRED)
 
 # Other deps not controlled by Conan
 find_package(Filesystem REQUIRED)

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,9 +5,9 @@ class PitchforkConanFile(CMakeConanFile):
     name = 'pf'
     version = '0.1.0'
     requires = (
-        'catch2/2.3.0@bincrafters/stable',
-        'spdlog/1.1.0@bincrafters/stable',
-        'boost/1.68.0@conan/stable',
+        'Catch2/2.8.0@catchorg/stable',
+        'spdlog/1.3.1@bincrafters/stable',
+        'boost/1.70.0@conan/stable',
     )
     build_args = ['-DBUILD_SPEC=NO']
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Catch2 2.3.0 REQUIRED)
+find_package(Catch2 2.8.0 REQUIRED)
 include(Catch)
 
 set(PF_TEST_BINDIR "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
Query tests may fail on Windows due to case insensitivity.